### PR TITLE
Add tensorboard callback + colab integration

### DIFF
--- a/Code/xNNs_Code_020_CIFAR.py
+++ b/Code/xNNs_Code_020_CIFAR.py
@@ -41,6 +41,8 @@
 # tensorflow 2.0 beta and tensorflow datasets
 !pip install tensorflow-gpu==2.0.0-beta1
 !pip install tensorflow-datasets
+%load_ext tensorboard
+%tensorboard --logdir logs
 
 # tenorflow
 import tensorflow as     tf
@@ -278,9 +280,10 @@ def plot_training_curves(history):
     plt.xlabel('epoch')
     plt.show()
 
-# callbacks (learning rate schedule, model checkpointing during training)
+# callbacks (learning rate schedule, model checkpointing during training, tensorboard)
 callbacks = [keras.callbacks.LearningRateScheduler(lr_schedule),
-             keras.callbacks.ModelCheckpoint(filepath=SAVE_MODEL_PATH+'model_{epoch}.h5', save_best_only=True, monitor='val_loss', verbose=1)]
+             keras.callbacks.ModelCheckpoint(filepath=SAVE_MODEL_PATH+'model_{epoch}.h5', save_best_only=True, monitor='val_loss', verbose=1),
+             keras.callbacks.TensorBoard()]
 
 # training
 initial_epoch_num = 0


### PR DESCRIPTION
Basic integration of Tensorboard into the CIFAR-10 demo. 

* Tensorboard callback params are left as default, but can be altered as needed. Writing images or weight histograms could be an interesting demo.
* Profiling does not currently work according to [this](https://github.com/tensorflow/tensorboard/issues/1913) issue.
* Graph visualization and per-epoch loss/accuracy tracking was confirmed to work.
* May be wise to add a note about pasting the `%tensorboard` launch command into a separate cell. It will work as a single code cell, but it becomes difficult to interact with Tensorboard in this case.
* The Tensorboard launch command must come before `model.fit()`. Otherwise Tensorboard will not launch until training has finished.